### PR TITLE
Add compatibility for CE: FastTrack Edition

### DIFF
--- a/Patches/CE_Patch_FSX_Refining.xml
+++ b/Patches/CE_Patch_FSX_Refining.xml
@@ -4,6 +4,7 @@
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>Combat Extended</li>
+			<li>Combat Extended: FastTrack Edition</li>
 		</mods>
 		<match Class="PatchOperationSequence">
 			<operations>


### PR DESCRIPTION
This simply extends the existing FSX refinery patch so that it also works with CE:FT, a fork of the original CE mod.